### PR TITLE
removed options from footer

### DIFF
--- a/catalog/controller/information/sitemap.php
+++ b/catalog/controller/information/sitemap.php
@@ -1,6 +1,9 @@
 <?php
 class ControllerInformationSitemap extends Controller {
 	public function index() {
+		//Sitemap is disabled
+		$this->response->redirect($this->url->link('common/home', '', true));
+		
 		$this->load->language('information/sitemap');
 
 		$this->document->setTitle($this->language->get('heading_title'));

--- a/catalog/controller/product/manufacturer.php
+++ b/catalog/controller/product/manufacturer.php
@@ -1,6 +1,9 @@
 <?php
 class ControllerProductManufacturer extends Controller {
 	public function index() {
+		//temporarily disabled branding page until it can be cleaned up
+		$this->response->redirect($this->url->link('common/home', '', true));
+
 		$this->load->language('product/manufacturer');
 
 		$this->load->model('catalog/manufacturer');

--- a/catalog/view/theme/default/template/common/footer.twig
+++ b/catalog/view/theme/default/template/common/footer.twig
@@ -16,13 +16,11 @@
         <ul class="list-unstyled">
           <li><a href="{{ contact }}">{{ text_contact }}</a></li>
           <li><a href="{{ return }}">{{ text_return }}</a></li>
-          <li><a href="{{ sitemap }}">{{ text_sitemap }}</a></li>
         </ul>
       </div>
       <div class="col-sm-3">
         <h5>{{ text_extra }}</h5>
         <ul class="list-unstyled">
-          <li><a href="{{ manufacturer }}">{{ text_manufacturer }}</a></li>
           <li><a href="{{ voucher }}">{{ text_voucher }}</a></li>
           <li><a href="{{ affiliate }}">{{ text_affiliate }}</a></li>
           <li><a href="{{ special }}">{{ text_special }}</a></li>
@@ -37,8 +35,6 @@
         </ul>
       </div>
     </div>
-    <hr>
-    <p>{{ powered }}</p>
   </div>
 </footer>
 {% for script in scripts %}


### PR DESCRIPTION
Removed sitemap, brand, and powered by open cart from footer
Trying to enter the sitemap and brand pages now redirects the user to the homepage.